### PR TITLE
Add audible.ca as lookup option.

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -35,6 +35,7 @@ intl_sites = {
 
 sites_langs = {
     'www.audible.com': {'lang': 'en'},
+    'www.audible.ca': {'lang': 'en'},
     'www.audible.co.uk': {'lang': 'en'},
     'www.audible.com.au': {'lang': 'en'},
     'www.audible.fr': {'lang': 'fr'},

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -6,7 +6,7 @@
     "id"      : "site",
     "label"   : "Select Audible site to use: ",
     "type"    : "enum",
-    "values"  : ["www.audible.com","www.audible.co.uk","www.audible.com.au","www.audible.de","www.audible.fr","www.audible.it"],
+    "values"  : ["www.audible.com","www.audible.ca","www.audible.co.uk","www.audible.com.au","www.audible.de","www.audible.fr","www.audible.it"],
     "default" : "www.audible.com"
 },{
 	"id": "debug",


### PR DESCRIPTION
This is a simple change to add the Canadian Audible site as one of the options for metadata lookups.