### PR TITLE
Updates from unending fork; pep8

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -17,20 +17,53 @@ def json_decode(output):
 # URLs
 VERSION_NO = '1.2019.07.29.1'
 
-REQUEST_DELAY = 10  # Delay used when requesting HTML, may be good to have to prevent being banned from the site
+# Delay used when requesting HTML,
+# may be good to have to prevent being banned from the site
+REQUEST_DELAY = 10
 
-INITIAL_SCORE = 100  # Starting value for score before deductions are taken.
-GOOD_SCORE = 98  # Score required to short-circuit matching and stop searching.
-IGNORE_SCORE = 45  # Any score lower than this will be ignored.
+# Starting value for score before deductions are taken.
+INITIAL_SCORE = 100
+# Score required to short-circuit matching and stop searching.
+GOOD_SCORE = 98
+# Any score lower than this will be ignored.
+IGNORE_SCORE = 45
 
 THREAD_MAX = 20
 
 intl_sites = {
-    'en': {'url': 'www.audible.com', 'urltitle': u'title=', 'rel_date': u'Release date', 'nar_by': u'Narrated By', 'nar_by2': u'Narrated by'},
-    'fr': {'url': 'www.audible.fr', 'urltitle': u'title=', 'rel_date': u'Date de publication', 'nar_by': u'Narrateur(s)', 'nar_by2': u'Lu par'},
-    'de': {'url': 'www.audible.de', 'urltitle': u'title=', 'rel_date': u'Erscheinungsdatum', 'nar_by': u'Gesprochen von', 'rel_date2': u'Veröffentlicht'},
-    'it': {'url': 'www.audible.it', 'urltitle': u'title=', 'rel_date': u'Data di Pubblicazione', 'nar_by': u'Narratore'},
-    # 'jp' : { 'url': 'www.audible.co.jp', 'rel_date' : u'N/A', 'nar_by' : u'ナレーター'     }, # untested
+    'en': {
+        'url': 'www.audible.com',
+        'urltitle': u'title=',
+        'rel_date': u'Release date',
+        'nar_by': u'Narrated By',
+        'nar_by2': u'Narrated by'
+    },
+    'fr': {
+        'url': 'www.audible.fr',
+        'urltitle': u'title=',
+        'rel_date': u'Date de publication',
+        'nar_by': u'Narrateur(s)',
+        'nar_by2': u'Lu par'
+    },
+    'de': {
+        'url': 'www.audible.de',
+        'urltitle': u'title=',
+        'rel_date': u'Erscheinungsdatum',
+        'nar_by': u'Gesprochen von',
+        'rel_date2': u'Veröffentlicht'
+    },
+    'it': {
+        'url': 'www.audible.it',
+        'urltitle': u'title=',
+        'rel_date': u'Data di Pubblicazione',
+        'nar_by': u'Narratore'
+    },
+    # untested
+    # 'jp': {
+        # 'url': 'www.audible.co.jp',
+        # 'rel_date': u'N/A',
+        # 'nar_by': u'ナレーター'
+    # },
 }
 
 sites_langs = {
@@ -70,16 +103,37 @@ def SetupUrls(sitetype, base, lang='en'):
                 ctx['REL_DATE_INFO'] = ctx['REL_DATE']
                 ctx['NAR_BY'] = 'Narrated By'
                 ctx['NAR_BY_INFO'] = 'Narrated by'
-        Log('Sites language is : %s', lang)
-        Log('/******************************LANG DEBUGGING************************************/')
-        Log('/* REL_DATE = %s', ctx['REL_DATE'])
-        Log('/* REL_DATE_INFO = %s', ctx['REL_DATE_INFO'])
-        Log('/* NAR_BY = %s', ctx['NAR_BY'])
-        Log('/* NAR_BY_INFO = %s', ctx['NAR_BY_INFO'])
-        Log('/********************************************************************************/')
+        Log(
+            'Sites language is : %s', lang
+            )
+        Log(
+            '/************************************'
+            'LANG DEBUGGING'
+            '************************************/'
+            )
+        Log(
+            '/* REL_DATE = %s', ctx['REL_DATE']
+            )
+        Log(
+            '/* REL_DATE_INFO = %s', ctx['REL_DATE_INFO']
+            )
+        Log(
+            '/* NAR_BY = %s', ctx['NAR_BY']
+            )
+        Log(
+            '/* NAR_BY_INFO = %s', ctx['NAR_BY_INFO']
+            )
+        Log(
+            '/****************************************'
+            '****************************************/'
+            )
     else:
-        Log('Audible site will be chosen by library language')
-        Log('Library Language is %s', lang)
+        Log(
+            'Audible site will be chosen by library language'
+            )
+        Log(
+            'Library Language is %s', lang
+            )
         if base is None:
             base = 'www.audible.com'
         if lang in intl_sites:
@@ -103,18 +157,53 @@ def SetupUrls(sitetype, base, lang='en'):
 
     AUD_BASE_URL = 'https://' + str(base) + '/'
     AUD_TITLE_URL = urlsearchtitle
-    ctx['AUD_BOOK_INFO'] = AUD_BASE_URL + 'pd/%s?ipRedirectOverride=true'
-    ctx['AUD_ARTIST_SEARCH_URL'] = AUD_BASE_URL + 'search?searchAuthor=%s&ipRedirectOverride=true'
-    ctx['AUD_ALBUM_SEARCH_URL'] = AUD_BASE_URL + 'search?' + AUD_TITLE_URL + '%s&x=41&ipRedirectOverride=true'
-    ctx['AUD_KEYWORD_SEARCH_URL'] = AUD_BASE_URL + 'search?filterby=field-keywords&advsearchKeywords=%s&x=41&ipRedirectOverride=true'
-    ctx['AUD_SEARCH_URL'] = AUD_BASE_URL + 'search?' + AUD_TITLE_URL + '{0}&searchAuthor={1}&x=41&ipRedirectOverride=true'
+
+    AUD_BOOK_INFO_ARR = [
+        AUD_BASE_URL,
+        'pd/%s?ipRedirectOverride=true',
+    ]
+    ctx['AUD_BOOK_INFO'] = ''.join(AUD_BOOK_INFO_ARR)
+
+    AUD_ARTIST_SEARCH_URL_ARR = [
+        AUD_BASE_URL,
+        'search?searchAuthor=%s&ipRedirectOverride=true',
+    ]
+    ctx['AUD_ARTIST_SEARCH_URL'] = ''.join(AUD_ARTIST_SEARCH_URL_ARR)
+
+    AUD_ALBUM_SEARCH_URL_ARR = [
+        AUD_BASE_URL,
+        'search?',
+        AUD_TITLE_URL,
+        '%s&x=41&ipRedirectOverride=true',
+    ]
+    ctx['AUD_ALBUM_SEARCH_URL'] = ''.join(AUD_ALBUM_SEARCH_URL_ARR)
+
+    AUD_KEYWORD_SEARCH_URL_ARR = [
+        AUD_BASE_URL,
+        ('search?filterby=field-keywords&advsearchKeywords=%s'
+            '&x=41&ipRedirectOverride=true'),
+    ]
+    ctx['AUD_KEYWORD_SEARCH_URL'] = ''.join(AUD_KEYWORD_SEARCH_URL_ARR)
+
+    AUD_SEARCH_URL_ARR = [
+        AUD_BASE_URL,
+        'search?',
+        AUD_TITLE_URL,
+        '{0}&searchAuthor={1}&x=41&ipRedirectOverride=true',
+    ]
+    ctx['AUD_SEARCH_URL'] = ''.join(AUD_SEARCH_URL_ARR)
+
     return ctx
 
 
 def Start():
     # HTTP.ClearCache()
     HTTP.CacheTime = CACHE_1WEEK
-    HTTP.Headers['User-agent'] = 'Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.2; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0)'
+    HTTP.Headers['User-agent'] = (
+        'Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.2; Trident/4.0;'
+        'SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729;'
+        'Media Center PC 6.0'
+    )
     HTTP.Headers['Accept-Encoding'] = 'gzip'
 
 
@@ -168,12 +257,16 @@ class AudiobookArtist(Agent.Artist):
         found = []
 
         for r in html.xpath('//div[a/img[@class="yborder"]]'):
-            date = self.getDateFromString(self.getStringContentFromXPath(r, 'text()[1]'))
+            date = self.getDateFromString(
+                self.getStringContentFromXPath(r, 'text()[1]')
+            )
             title = self.getStringContentFromXPath(r, 'a[2]')
             murl = self.getAnchorUrlFromXPath(r, 'a[2]')
             thumb = self.getImageUrlFromXPath(r, 'a/img')
 
-            found.append({'url': murl, 'title': title, 'date': date, 'thumb': thumb})
+            found.append(
+                {'url': murl, 'title': title, 'date': date, 'thumb': thumb}
+            )
 
         return found
 
@@ -184,11 +277,26 @@ class AudiobookArtist(Agent.Artist):
         # author source is identified.
 
         # Log some stuff
-        self.Log('---------------------------------ARTIST SEARCH--------------------------------------------------')
-        self.Log('* Album:           %s', media.album)
-        self.Log('* Artist:           %s', media.artist)
-        self.Log('****************************************Not Ready For Artist Search Yet*************************')
-        self.Log('------------------------------------------------------------------------------------------------')
+        self.Log(
+            '------------------------------------------------'
+            'ARTIST SEARCH'
+            '------------------------------------------------'
+        )
+        self.Log(
+            '* Album:           %s', media.album
+        )
+        self.Log(
+            '* Artist:           %s', media.artist
+        )
+        self.Log(
+            '****************************************'
+            'Not Ready For Artist Search Yet'
+            '****************************************'
+        )
+        self.Log(
+            '------------------------------------------------'
+            '------------------------------------------------'
+        )
         return
 
     def update(self, metadata, media, lang, force=False):
@@ -262,32 +370,115 @@ class AudiobookAlbum(Agent.Album):
     def doSearch(self, url, ctx):
         html = HTML.ElementFromURL(url, sleep=REQUEST_DELAY)
         found = []
-        self.Log('-----------------------------------------just before new xpath line--------------------')
+        self.Log(
+            '-----------------------------------------'
+            'just before new xpath line'
+            '-----------------------------------------'
+            )
         for r in html.xpath('//ul//li[contains(@class,"productListItem")]'):
-            datetext = self.getStringContentFromXPath(r, u'div/div/div/div/div/div/span/ul/li[contains (@class,"releaseDateLabel")]/span')
+            datetext = self.getStringContentFromXPath(
+                r, (
+                    u'div/div/div/div/div/div/span/ul/li'
+                    '[contains (@class,"releaseDateLabel")]/span'
+                    )
+            )
             datetext = re.sub(r'[^0-9\-]', '', datetext)
             date = self.getDateFromString(datetext)
-            title = self.getStringContentFromXPath(r, 'div/div/div/div/div/div/span/ul//a[contains (@class,"bc-link")][1]')
-            murl = self.getAnchorUrlFromXPath(r, 'div/div/div/div/div/div/span/ul/li/h3//a[1]')
-            thumb = self.getImageUrlFromXPath(r, 'div/div/div/div/div/div/div[contains(@class,"responsive-product-square")]/div/a/img')
-            author = self.getStringContentFromXPath(r, 'div/div/div/div/div/div/span/ul/li[contains (@class,"authorLabel")]/span/a[1]')
-            narrator = self.getStringContentFromXPath(r, u'div/div/div/div/div/div/span/ul/li[contains (@class,"narratorLabel")]/span//a[1]'.format(ctx['NAR_BY']))
-            self.Log('---------------------------------------XPATH SEARCH HIT-----------------------------------------------')
+            title = self.getStringContentFromXPath(
+                r, (
+                    'div/div/div/div/div/div/span/ul//a'
+                    '[contains (@class,"bc-link")][1]'
+                    )
+            )
+            murl = self.getAnchorUrlFromXPath(
+                r, 'div/div/div/div/div/div/span/ul/li/h3//a[1]'
+            )
+            thumb = self.getImageUrlFromXPath(
+                r, 'div/div/div/div/div/div/div'
+                '[contains(@class,"responsive-product-square")]/div/a/img'
+            )
+            author = self.getStringContentFromXPath(
+                r, (
+                    'div/div/div/div/div/div/span/ul'
+                    '/li[contains (@class,"authorLabel")]/span/a[1]'
+                )
+            )
+            narrator = self.getStringContentFromXPath(
+                r, (
+                    u'div/div/div/div/div/div/span/ul/li'
+                    '[contains (@class,"narratorLabel")]/span//a[1]'
+                ).format(ctx['NAR_BY'])
+            )
+            self.Log(
+                '-----------------------------------------------'
+                'XPATH SEARCH HIT'
+                '-----------------------------------------------'
+            )
 
-            found.append({'url': murl, 'title': title, 'date': date, 'thumb': thumb, 'author': author, 'narrator': narrator})
+            found.append(
+                {
+                    'url': murl,
+                    'title': title,
+                    'date': date,
+                    'thumb': thumb,
+                    'author': author,
+                    'narrator': narrator
+                }
+            )
 
-        self.Log('-----------------------------------------just after new xpath line--------------------')
+        self.Log(
+            '-----------------------------------------'
+            'just after new xpath line'
+            '-----------------------------------------'
+            )
 
         for r in html.xpath('//div[contains (@class, "adbl-search-result")]'):
-            date = self.getDateFromString(self.getStringContentFromXPath(r, u'div/div/ul/li[contains (., "{0}")]/span[2]//text()'.format(ctx['REL_DATE'])))
-            title = self.getStringContentFromXPath(r, 'div/div/div/div/a[1]')
-            murl = self.getAnchorUrlFromXPath(r, 'div/div/div/div/a[1]')
-            thumb = self.getImageUrlFromXPath(r, 'div[contains (@class,"adbl-prod-image-sample-cont")]/a/img')
-            author = self.getStringContentFromXPath(r, 'div/div/ul/li//a[contains (@class,"author-profile-link")][1]')
-            narrator = self.getStringContentFromXPath(r, u'div/div/ul/li[contains (., "{0}")]//a[1]'.format(ctx['NAR_BY']))
-            self.Log('---------------------------------------XPATH SEARCH HIT-----------------------------------------------')
+            date = self.getDateFromString(
+                self.getStringContentFromXPath(
+                    r, (
+                        u'div/div/ul/li[contains (., "{0}")]'
+                        '/span[2]//text()'
+                        ).format(
+                        ctx['REL_DATE']
+                    )
+                )
+            )
+            title = self.getStringContentFromXPath(
+                r, 'div/div/div/div/a[1]'
+            )
+            murl = self.getAnchorUrlFromXPath(
+                r, 'div/div/div/div/a[1]'
+            )
+            thumb = self.getImageUrlFromXPath(
+                r, 'div[contains (@class,"adbl-prod-image-sample-cont")]/a/img'
+            )
+            author = self.getStringContentFromXPath(
+                r, (
+                        'div/div/ul/li/'
+                        '/a[contains (@class,"author-profile-link")][1]'
+                    )
+            )
+            narrator = self.getStringContentFromXPath(
+                r, u'div/div/ul/li[contains (., "{0}")]//a[1]'.format(
+                    ctx['NAR_BY']
+                )
+            )
+            self.Log(
+                '-----------------------------------------------'
+                'XPATH SEARCH HIT'
+                '-----------------------------------------------'
+            )
 
-            found.append({'url': murl, 'title': title, 'date': date, 'thumb': thumb, 'author': author, 'narrator': narrator})
+            found.append(
+                {
+                    'url': murl,
+                    'title': title,
+                    'date': date,
+                    'thumb': thumb,
+                    'author': author,
+                    'narrator': narrator
+                }
+            )
 
         return found
 
@@ -295,15 +486,23 @@ class AudiobookAlbum(Agent.Album):
         ctx = SetupUrls(Prefs['sitetype'], Prefs['site'], lang)
         LCL_IGNORE_SCORE = IGNORE_SCORE
 
-        self.Log('---------------------------------------ALBUM SEARCH-----------------------------------------------')
+        self.Log(
+            '-----------------------------------------------'
+            'ALBUM SEARCH'
+            '-----------------------------------------------'
+        )
         self.Log('* ID:              %s', media.parent_metadata.id)
         self.Log('* Title:           %s', media.title)
         self.Log('* Name:            %s', media.name)
         self.Log('* Album:           %s', media.album)
         self.Log('* Artist:          %s', media.artist)
-        self.Log('--------------------------------------------------------------------------------------------------')
+        self.Log(
+            '-------------------------------------------------'
+            '-------------------------------------------------'
+    )
 
-        # Handle a couple of edge cases where album search will give bad results.
+        # Handle a couple of edge cases where
+        # album search will give bad results.
         if media.album is None and not manual:
             self.Log('Album Title is NULL on an automatic search.  Returning')
             return
@@ -312,48 +511,81 @@ class AudiobookAlbum(Agent.Album):
             return
 
         if manual:
-            Log('You clicked \'fix match\'. This may have returned no useful results because it\'s searching using the title of the first track.')
-            Log('There\'s not currently a way around this initial failure. But clicking \'Search Options\' and entering the title works just fine.')
-            Log('This message will appear during the initial search and the actual manual search.')
-            # If this is a custom search, use the user-entered name instead of the scanner hint.
-            Log('Custom album search for: ' + media.name)
+            Log(
+                'You clicked \'fix match\'. '
+                'This may have returned no useful results because '
+                'it\'s searching using the title of the first track.'
+            )
+            Log(
+                'There\'s not currently a way around this initial failure. '
+                'But clicking \'Search Options\' and '
+                'entering the title works just fine.'
+            )
+            Log(
+                'This message will appear during the initial '
+                'search and the actual manual search.'
+            )
+            # If this is a custom search,
+            # use the user-entered name instead of the scanner hint.
+            Log(
+                'Custom album search for: ' + media.name
+            )
             # media.title = media.name
             media.album = media.name
         else:
             Log('Album search: ' + media.title)
 
         # Log some stuff for troubleshooting detail
-        self.Log('-----------------------------------------------------------------------')
+        self.Log(
+            '-----------------------------------'
+            '------------------------------------'
+        )
         self.Log('* ID:              %s', media.parent_metadata.id)
         self.Log('* Title:           %s', media.title)
         self.Log('* Name:            %s', media.name)
         self.Log('* Name:            %s', media.album)
-        self.Log('-----------------------------------------------------------------------')
+        self.Log(
+            '-----------------------------------'
+            '------------------------------------'
+        )
 
         # Normalize the name
         normalizedName = String.StripDiacritics(media.album)
         if len(normalizedName) == 0:
             normalizedName = media.album
-        Log('normalizedName = %s', normalizedName)
+        Log(
+            'normalizedName = %s', normalizedName
+        )
 
         # Chop off "unabridged"
         normalizedName = re.sub(r"[\(\[].*?[\)\]]", "", normalizedName)
-        Log('chopping bracketed text = %s', normalizedName)
+        Log(
+            'chopping bracketed text = %s', normalizedName
+        )
         normalizedName = normalizedName.strip()
-        Log('normalizedName stripped = %s', normalizedName)
+        Log(
+            'normalizedName stripped = %s', normalizedName
+        )
 
-        self.Log('***** SEARCHING FOR "%s" - AUDIBLE v.%s *****', normalizedName, VERSION_NO)
+        self.Log(
+            '***** SEARCHING FOR "%s" - AUDIBLE v.%s *****',
+            normalizedName, VERSION_NO
+        )
 
         # Make the URL
-        match = re.search("(?P<book_title>.*?)\[(?P<source>(audible))-(?P<guid>B[a-zA-Z0-9]{9,9})\]", media.title, re.IGNORECASE)
-        if match:  ###metadata id provided
-            Log('Looks like you went through the trouble of adding the audible ID to the Book title...')
-            searchUrl = ctx['AUD_KEYWORD_SEARCH_URL'] % (String.Quote((match.group('guid')).encode('utf-8'), usePlus=True))
-            LCL_IGNORE_SCORE = 0
-        elif media.artist is not None:
-            searchUrl = ctx['AUD_SEARCH_URL'].format((String.Quote((normalizedName).encode('utf-8'), usePlus=True)), (String.Quote((media.artist).encode('utf-8'), usePlus=True)))
+        if media.artist is not None:
+            searchUrl = ctx['AUD_SEARCH_URL'].format(
+                (
+                    String.Quote((normalizedName).encode('utf-8'), usePlus=True)
+                ),
+                (
+                    String.Quote((media.artist).encode('utf-8'), usePlus=True)
+                )
+            )
         else:
-            searchUrl = ctx['AUD_ALBUM_SEARCH_URL'] % (String.Quote((normalizedName).encode('utf-8'), usePlus=True))
+            searchUrl = ctx['AUD_KEYWORD_SEARCH_URL'] % (
+                String.Quote((normalizedName).encode('utf-8'), usePlus=True)
+            )
         found = self.doSearch(searchUrl, ctx)
 
         # Write search result status to log
@@ -361,13 +593,23 @@ class AudiobookAlbum(Agent.Album):
             self.Log('No results found for query "%s"', normalizedName)
             return
         else:
-            self.Log('Found %s result(s) for query "%s"', len(found), normalizedName)
+            self.Log(
+                'Found %s result(s) for query "%s"', len(found), normalizedName
+            )
             i = 1
             for f in found:
-                self.Log('    %s. (title) %s (author) %s (url)[%s] (date)(%s) (thumb){%s}', i, f['title'], f['author'], f['url'], str(f['date']), f['thumb'])
+                self.Log(
+                    '    %s. (title) %s (author) %s (url)[%s]'
+                    ' (date)(%s) (thumb){%s}',
+                    i, f['title'], f['author'],
+                    f['url'], str(f['date']), f['thumb']
+                )
                 i += 1
 
-        self.Log('-----------------------------------------------------------------------')
+        self.Log(
+            '-----------------------------------'
+            '------------------------------------'
+        )
         # Walk the found items and gather extended information
         info = []
         i = 1
@@ -377,13 +619,15 @@ class AudiobookAlbum(Agent.Album):
 
             # Get the id
             for itemId in url.split('/'):
-                if re.match(r'^[0-9A-Z]{10,10}', itemId):  # IDs No longer start with just 'B0'
+                # IDs No longer start with just 'B0'
+                if re.match(r'^[0-9A-Z]{10,10}', itemId):
                     break
                 itemId = None
 
             # New Search results contain question marks after the ID
             for itemId in itemId.split('?'):
-                if re.match(r'^[0-9A-Z]{10,10}', itemId):  # IDs No longer start with just 'B0'
+                # IDs No longer start with just 'B0'
+                if re.match(r'^[0-9A-Z]{10,10}', itemId):
                     break
 
             if len(itemId) == 0:
@@ -408,14 +652,18 @@ class AudiobookAlbum(Agent.Album):
             # self.Log('scorebase1:    %s', scorebase1)
             # self.Log('scorebase2:    %s', scorebase2)
 
-            score = INITIAL_SCORE - Util.LevenshteinDistance(scorebase1, scorebase2)
+            score = INITIAL_SCORE - Util.LevenshteinDistance(
+                scorebase1, scorebase2
+            )
 
             if media.artist:
                 scorebase3 = media.artist
                 scorebase4 = author
                 # self.Log('scorebase3:    %s', scorebase3)
                 # self.Log('scorebase4:    %s', scorebase4)
-                score = INITIAL_SCORE - Util.LevenshteinDistance(scorebase3, scorebase4)
+                score = INITIAL_SCORE - Util.LevenshteinDistance(
+                    scorebase3, scorebase4
+                )
 
             self.Log('* Title is              %s', title)
             self.Log('* Author is             %s', author)
@@ -425,34 +673,75 @@ class AudiobookAlbum(Agent.Album):
             self.Log('* Thumb is              %s', thumb)
 
             if score >= LCL_IGNORE_SCORE:
-                info.append({'id': itemId, 'title': title, 'year': year, 'date': date, 'score': score, 'thumb': thumb, 'artist': author})
+                info.append(
+                    {
+                        'id': itemId,
+                        'title': title,
+                        'year': year,
+                        'date': date,
+                        'score': score,
+                        'thumb': thumb,
+                        'artist': author
+                    }
+                )
             else:
-                self.Log('# Score is below ignore boundary (%s)... Skipping!', LCL_IGNORE_SCORE)
+                self.Log(
+                    '# Score is below ignore boundary (%s)... Skipping!',
+                    LCL_IGNORE_SCORE
+                )
 
             if i != len(found):
-                self.Log('-----------------------------------------------------------------------')
+                self.Log(
+                    '-----------------------------------'
+                    '------------------------------------'
+                )
 
             i += 1
 
         info = sorted(info, key=lambda inf: inf['score'], reverse=True)
 
         # Output the final results.
-        self.Log('***********************************************************************')
+        self.Log(
+            '***********************************'
+            '************************************'
+        )
         self.Log('Final result:')
         i = 1
         for r in info:
-            description = '\"%s\" by %s [%s]' % (r['title'], r['artist'], r['year'])
-            self.Log('    [%s]    %s. %s (%s) %s {%s} [%s]', r['score'], i, r['title'], r['year'], r['artist'], r['id'], r['thumb'])
-            results.Append(MetadataSearchResult(id=r['id'], name=description, score=r['score'], thumb=r['thumb'], lang=lang))
+            description = '\"%s\" by %s [%s]' % (
+                r['title'], r['artist'], r['year']
+            )
+            self.Log(
+                '    [%s]    %s. %s (%s) %s {%s} [%s]',
+                r['score'], i, r['title'], r['year'],
+                r['artist'], r['id'], r['thumb']
+            )
+            results.Append(
+                MetadataSearchResult(
+                    id=r['id'],
+                    name=description,
+                    score=r['score'],
+                    thumb=r['thumb'],
+                    lang=lang
+                )
+            )
 
-            # If there are more than one result, and this one has a score that is >= GOOD SCORE, then ignore the rest of the results
+            # If there are more than one result,
+            # and this one has a score that is >= GOOD SCORE,
+            # then ignore the rest of the results
             if not manual and len(info) > 1 and r['score'] >= GOOD_SCORE:
-                self.Log('            *** The score for these results are great, so we will use them, and ignore the rest. ***')
+                self.Log(
+                    '            *** The score for these results are great, '
+                    'so we will use them, and ignore the rest. ***'
+                )
                 break
             i += 1
 
     def update(self, metadata, media, lang, force=False):
-        self.Log('***** UPDATING "%s" ID: %s - AUDIBLE v.%s *****', media.title, metadata.id, VERSION_NO)
+        self.Log(
+            '***** UPDATING "%s" ID: %s - AUDIBLE v.%s *****',
+            media.title, metadata.id, VERSION_NO
+        )
         ctx = SetupUrls(Prefs['sitetype'], Prefs['site'], lang)
 
         # Make url
@@ -470,28 +759,71 @@ class AudiobookAlbum(Agent.Album):
         genre2 = None
 
         for r in html.xpath('//div[contains (@id, "adbl_page_content")]'):
-            date = self.getDateFromString(self.getStringContentFromXPath(r, u'//li[contains (., "{0}")]/span[2]//text()'.format(ctx['REL_DATE_INFO'])))
-            title = self.getStringContentFromXPath(r, '//h1[contains (@class, "adbl-prod-h1-title")]/text()')
-            murl = self.getAnchorUrlFromXPath(r, 'div/div/div/div/a[1]')
-            thumb = self.getImageUrlFromXPath(r, 'div/div/div/div/div/img')
-            author = self.getStringContentFromXPath(r, '//li//a[contains (@class,"author-profile-link")][1]')
-            narrator = self.getStringContentFromXPath(r, '//li[contains (., "{0}")]//span[2]'.format(ctx['NAR_BY_INFO'])).strip().decode('utf-8')
-            studio = self.getStringContentFromXPath(r, '//li//a[contains (@id,"PublisherSearchLink")][1]')
-            synopsis = self.getStringContentFromXPath(r, '//div[contains (@class, "disc-summary")]/div[*]').strip()
-            series = self.getStringContentFromXPath(r, '//div[contains (@class, "adbl-series-link")]//a[1]')
-            genre1 = self.getStringContentFromXPath(r, '//div[contains(@class,"adbl-pd-breadcrumb")]/div[2]/a/span/text()')
-            genre2 = self.getStringContentFromXPath(r, '//div[contains(@class,"adbl-pd-breadcrumb")]/div[3]/a/span/text()')
-            self.Log('---------------------------------------XPATH SEARCH HIT-----------------------------------------------')
+            date = self.getDateFromString(
+                self.getStringContentFromXPath(
+                    r, u'//li[contains (., "{0}")]/span[2]//text()'.format(
+                        ctx['REL_DATE_INFO']
+                    )
+                )
+            )
+            title = self.getStringContentFromXPath(
+                r, '//h1[contains (@class, "adbl-prod-h1-title")]/text()'
+            )
+            murl = self.getAnchorUrlFromXPath(
+                r, 'div/div/div/div/a[1]'
+            )
+            thumb = self.getImageUrlFromXPath(
+                r, 'div/div/div/div/div/img'
+            )
+            author = self.getStringContentFromXPath(
+                r, '//li//a[contains (@class,"author-profile-link")][1]'
+            )
+            narrator = self.getStringContentFromXPath(
+                r, '//li[contains (., "{0}")]//span[2]'.format(
+                    ctx['NAR_BY_INFO']
+                )
+            ).strip().decode('utf-8')
+            studio = self.getStringContentFromXPath(
+                r, '//li//a[contains (@id,"PublisherSearchLink")][1]'
+            )
+            synopsis = self.getStringContentFromXPath(
+                r, '//div[contains (@class, "disc-summary")]/div[*]'
+            ).strip()
+            series = self.getStringContentFromXPath(
+                r, '//div[contains (@class, "adbl-series-link")]//a[1]'
+            )
+            genre1 = self.getStringContentFromXPath(
+                r, (
+                    '//div[contains(@class,"adbl-pd-breadcrumb")]'
+                    '/div[2]/a/span/text()'
+                )
+            )
+            genre2 = self.getStringContentFromXPath(
+                r, (
+                    '//div[contains(@class,"adbl-pd-breadcrumb")]'
+                    '/div[3]/a/span/text()'
+                )
+            )
+            self.Log(
+                '-----------------------------------------------'
+                'XPATH SEARCH HIT'
+                '-----------------------------------------------'
+            )
 
         if date is None:
             # for r in html.xpath('//div[contains (@class,"slot bottomSlot")]/script[contains (@type, "application/ld+json")]'):
-            for r in html.xpath('//script[contains (@type, "application/ld+json")]'):
+            for r in html.xpath(
+                '//script[contains (@type, "application/ld+json")]'
+            ):
                 page_content = r.text_content()
                 page_content = page_content.replace('\n', '')
                 # page_content = page_content.replace('\'', '\\\'')
                 # page_content = re.sub(r'\\(?![bfnrtv\'\"\\])', '', page_content)
-                # Remove any backslashes that aren't escaping a character JSON needs escaped
-                remove_inv_json_esc = re.compile(r'([^\\])(\\(?![bfnrt\'\"\\/]|u[A-Fa-f0-9]{4}))')
+                # Remove any backslashes that aren't
+                # escaping a character JSON needs escaped
+                remove_inv_json_esc = re.compile(
+                    r'([^\\])(\\(?![bfnrt\'\"\\/]|u[A-Fa-f0-9]{4}))'
+                )
                 page_content = remove_inv_json_esc.sub(r'\1\\\2', page_content)
                 self.Log(page_content)
                 json_data = json_decode(page_content)
@@ -499,7 +831,9 @@ class AudiobookAlbum(Agent.Album):
                     if 'datePublished' in json_data:
                         # for key in json_data:
                         #    Log('{0}:{1}'.format(key, json_data[key]))
-                        date = self.getDateFromString(json_data['datePublished'])
+                        date = self.getDateFromString(
+                            json_data['datePublished']
+                        )
                         title = json_data['name']
                         thumb = json_data['image']
                         rating = json_data['aggregateRating']['ratingValue']
@@ -522,14 +856,20 @@ class AudiobookAlbum(Agent.Album):
                     if 'itemListElement' in json_data:
                         # for key in json_data:
                         #    Log('{0}:{1}'.format(key, json_data[key]))
-                        genre1 = json_data['itemListElement'][1]['item']['name']
+                        genre1 = (
+                            json_data['itemListElement'][1]['item']['name']
+                        )
                         try:
-                            genre2 = json_data['itemListElement'][2]['item']['name']
+                            genre2 = (
+                                json_data['itemListElement'][2]['item']['name']
+                            )
                         except:
                             continue
 
             for r in html.xpath('//li[contains (@class, "seriesLabel")]'):
-                series = self.getStringContentFromXPath(r, '//li[contains (@class, "seriesLabel")]//a[1]')
+                series = self.getStringContentFromXPath(
+                    r, '//li[contains (@class, "seriesLabel")]//a[1]'
+                )
                 # Log(series.strip())
 
         # cleanup synopsis
@@ -606,16 +946,31 @@ class AudiobookAlbum(Agent.Album):
     def addTask(self, queue, func, *args, **kargs):
         queue.put((func, args, kargs))
 
-    ### Writes metadata information to log.
+    # Writes metadata information to log.
     def writeInfo(self, header, url, metadata):
         self.Log(header)
-        self.Log('-----------------------------------------------------------------------')
-        self.Log('* ID:              %s', metadata.id)
-        self.Log('* URL:             %s', url)
-        self.Log('* Title:           %s', metadata.title)
-        self.Log('* Release date:    %s', str(metadata.originally_available_at))
-        self.Log('* Studio:          %s', metadata.studio)
-        self.Log('* Summary:         %s', metadata.summary)
+        self.Log(
+            '-----------------------------------'
+            '------------------------------------'
+        )
+        self.Log(
+            '* ID:              %s', metadata.id
+        )
+        self.Log(
+            '* URL:             %s', url
+        )
+        self.Log(
+            '* Title:           %s', metadata.title
+        )
+        self.Log(
+            '* Release date:    %s', str(metadata.originally_available_at)
+        )
+        self.Log(
+            '* Studio:          %s', metadata.studio
+        )
+        self.Log(
+            '* Summary:         %s', metadata.summary
+        )
 
         if len(metadata.collections) > 0:
             self.Log('|\\')
@@ -637,7 +992,10 @@ class AudiobookAlbum(Agent.Album):
             for art in metadata.art.keys():
                 self.Log('| * Fan art URL:   %s', art)
 
-        self.Log('***********************************************************************')
+        self.Log(
+            '***********************************'
+            '************************************'
+            )
 
 
 def safe_unicode(s, encoding='utf-8'):

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -15,7 +15,7 @@ def json_decode(output):
 
 
 # URLs
-VERSION_NO = '1.2019.07.29.1'
+VERSION_NO = '1.2021.08.24.1'
 
 # Delay used when requesting HTML,
 # may be good to have to prevent being banned from the site
@@ -528,9 +528,8 @@ class AudiobookAlbum(Agent.Album):
             # If this is a custom search,
             # use the user-entered name instead of the scanner hint.
             Log(
-                'Custom album search for: ' + media.name
+                'Custom album search for: ' + media.album
             )
-            # media.title = media.name
             media.album = media.name
         else:
             Log('Album search: ' + media.title)

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -755,13 +755,13 @@ class AudiobookAlbum(Agent.Album):
         date = None
         rating = None
         series = ''
-        series2=''
-        series_def=''
+        series2 = ''
+        series_def = ''
         genre1 = None
         genre2 = None
         volume = ''
-        volume2=''
-        volume_def=''
+        volume2 = ''
+        volume_def = ''
 
         for r in html.xpath('//div[contains (@id, "adbl_page_content")]'):
             date = self.getDateFromString(
@@ -983,6 +983,11 @@ class AudiobookAlbum(Agent.Album):
         # Set the date and year if found.
         if date is not None:
             metadata.originally_available_at = date
+
+        # Add the genres
+        metadata.genres.clear()
+        metadata.genres.add(genre1)
+        metadata.genres.add(genre2)
 
         # Add Narrators to Styles
         narrators_list = narrator.split(",")

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -58,12 +58,6 @@ intl_sites = {
         'rel_date': u'Data di Pubblicazione',
         'nar_by': u'Narratore'
     },
-    # untested
-    # 'jp': {
-        # 'url': 'www.audible.co.jp',
-        # 'rel_date': u'N/A',
-        # 'nar_by': u'ナレーター'
-    # },
 }
 
 sites_langs = {
@@ -326,7 +320,12 @@ class AudiobookArtist(Agent.Artist):
 
 class AudiobookAlbum(Agent.Album):
     name = 'Audiobooks'
-    languages = [Locale.Language.English, 'de', 'fr', 'it']
+    languages = [
+        Locale.Language.English,
+        'de',
+        'fr',
+        'it'
+    ]
     primary_provider = True
     accepts_from = ['com.plexapp.agents.localmedia']
 
@@ -499,7 +498,7 @@ class AudiobookAlbum(Agent.Album):
         self.Log(
             '-------------------------------------------------'
             '-------------------------------------------------'
-    )
+        )
 
         # Handle a couple of edge cases where
         # album search will give bad results.
@@ -507,7 +506,10 @@ class AudiobookAlbum(Agent.Album):
             self.Log('Album Title is NULL on an automatic search.  Returning')
             return
         if media.album == '[Unknown Album]' and not manual:
-            self.Log('Album Title is [Unknown Album] on an automatic search.  Returning')
+            self.Log(
+                'Album Title is [Unknown Album]'
+                ' on an automatic search.  Returning'
+            )
             return
 
         if manual:
@@ -528,7 +530,7 @@ class AudiobookAlbum(Agent.Album):
             # If this is a custom search,
             # use the user-entered name instead of the scanner hint.
             Log(
-                'Custom album search for: ' + media.album
+                'Custom album search for: ' + media.name
             )
             media.album = media.name
         else:
@@ -542,7 +544,7 @@ class AudiobookAlbum(Agent.Album):
         self.Log('* ID:              %s', media.parent_metadata.id)
         self.Log('* Title:           %s', media.title)
         self.Log('* Name:            %s', media.name)
-        self.Log('* Name:            %s', media.album)
+        self.Log('* Album:            %s', media.album)
         self.Log(
             '-----------------------------------'
             '------------------------------------'
@@ -815,14 +817,11 @@ class AudiobookAlbum(Agent.Album):
             )
 
         if date is None:
-            # for r in html.xpath('//div[contains (@class,"slot bottomSlot")]/script[contains (@type, "application/ld+json")]'):
             for r in html.xpath(
                 '//script[contains (@type, "application/ld+json")]'
             ):
                 page_content = r.text_content()
                 page_content = page_content.replace('\n', '')
-                # page_content = page_content.replace('\'', '\\\'')
-                # page_content = re.sub(r'\\(?![bfnrtv\'\"\\])', '', page_content)
                 # Remove any backslashes that aren't
                 # escaping a character JSON needs escaped
                 remove_inv_json_esc = re.compile(
@@ -833,8 +832,6 @@ class AudiobookAlbum(Agent.Album):
                 json_data = json_decode(page_content)
                 for json_data in json_data:
                     if 'datePublished' in json_data:
-                        # for key in json_data:
-                        #    Log('{0}:{1}'.format(key, json_data[key]))
                         date = json_data['datePublished']
                         title = json_data['name']
                         thumb = json_data['image']
@@ -860,8 +857,6 @@ class AudiobookAlbum(Agent.Album):
                         studio = json_data['publisher']
                         synopsis = json_data['description']
                     if 'itemListElement' in json_data:
-                        # for key in json_data:
-                        #    Log('{0}:{1}'.format(key, json_data[key]))
                         genre1 = (
                             json_data['itemListElement'][1]['item']['name']
                         )

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -533,7 +533,7 @@ class AudiobookAlbum(Agent.Album):
                 Log(
                     'Custom album search for: ' + media.name
                 )
-            media.album = media.name
+                media.album = media.name
         else:
             Log('Album search: ' + media.title)
 
@@ -994,7 +994,7 @@ class AudiobookAlbum(Agent.Album):
             ]:
                 metadata.styles.add(narrators.strip())
 
-        # Add Narrators to Moods
+        # Add Authors to Moods
         author_list = author.split(",")
         contributers_list = [
             'contributor',

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -1046,6 +1046,8 @@ class AudiobookAlbum(Agent.Album):
         )
         metadata.studio = studio
         metadata.summary = synopsis
+        metadata.posters[1] = Proxy.Media(HTTP.Request(thumb))
+        metadata.posters.validate_keys(thumb)
         # Use rating only when available
         if rating:
             metadata.rating = float(rating) * 2
@@ -1056,7 +1058,6 @@ class AudiobookAlbum(Agent.Album):
         metadata.collections.add(series)
         if series2:
             metadata.collections.add(series2)
-        # media.artist = author
         self.writeInfo('New data', url, metadata)
 
     def hasProxy(self):

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -441,8 +441,9 @@ class AudiobookAlbum(Agent.Album):
         self.Log('Final result:')
         i = 1
         for r in info:
+            description = '\"%s\" by %s [%s]' % (r['title'], r['artist'], r['year'])
             self.Log('    [%s]    %s. %s (%s) %s {%s} [%s]', r['score'], i, r['title'], r['year'], r['artist'], r['id'], r['thumb'])
-            results.Append(MetadataSearchResult(id=r['id'], name=r['title'], score=r['score'], thumb=r['thumb'], lang=lang))
+            results.Append(MetadataSearchResult(id=r['id'], name=description, score=r['score'], thumb=r['thumb'], lang=lang))
 
             # If there are more than one result, and this one has a score that is >= GOOD SCORE, then ignore the rest of the results
             if not manual and len(info) > 1 and r['score'] >= GOOD_SCORE:

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -529,9 +529,10 @@ class AudiobookAlbum(Agent.Album):
             )
             # If this is a custom search,
             # use the user-entered name instead of the scanner hint.
-            Log(
-                'Custom album search for: ' + media.name
-            )
+            if media.name:
+                Log(
+                    'Custom album search for: ' + media.name
+                )
             media.album = media.name
         else:
             Log('Album search: ' + media.title)
@@ -544,7 +545,7 @@ class AudiobookAlbum(Agent.Album):
         self.Log('* ID:              %s', media.parent_metadata.id)
         self.Log('* Title:           %s', media.title)
         self.Log('* Name:            %s', media.name)
-        self.Log('* Album:            %s', media.album)
+        self.Log('* Album:           %s', media.album)
         self.Log(
             '-----------------------------------'
             '------------------------------------'

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -9,6 +9,11 @@
     "values"  : ["www.audible.com","www.audible.co.uk","www.audible.com.au","www.audible.de","www.audible.fr","www.audible.it"],
     "default" : "www.audible.com"
 },{
+	"id": "copyyear",
+	"label": "User copyright year instead of datePublished",
+	"type": "bool",
+	"default": "false"
+},{
 	"id": "debug",
 	"label": "Ouput debugging info in logs",
 	"type": "bool",

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -10,7 +10,7 @@
     "default" : "www.audible.com"
 },{
 	"id": "copyyear",
-	"label": "User copyright year instead of datePublished",
+	"label": "Uses copyright year instead of datePublished",
 	"type": "bool",
 	"default": "false"
 },{


### PR DESCRIPTION
### Enhancements
- Update version string for clarity between forks.
- Make code PEP8/lint compliant.
- Remove unused code.
- Changes from [Unending fork](https://github.com/Unending/Audiobooks.bundle):
  - Add series to sort album field
  - strip when title ends with , Book #
  - Collection support if/when plex allows.
  - Add preference to use copyright year instead of published year.
  - Cleanup title edge cases.
  - Handle full cast and other author edge cases.
### Fixes
- bugfix when no rating
- fix log error when first clicking fix match (no `media.name`).
- Add posters back.