### PR TITLE
Improve score calculation; Fix crash on single-genre

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -10,7 +10,7 @@ from search_tools import SearchTool
 from update_tools import UpdateTool
 from urls import SiteUrl
 
-VERSION_NO = '2021.08.27.1'
+VERSION_NO = '2021.08.28.1'
 
 # Delay used when requesting HTML,
 # may be good to have to prevent being banned from the site

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -235,8 +235,8 @@ class AudiobookAlbum(Agent.Album):
 
         log.separator(
             msg=(
-                "UPDATING" + media.title + (
-                    "ID: " + metadata.id
+                "UPDATING: " + media.title + (
+                    " ID: " + metadata.id
                 )
             ),
             log_level="info"
@@ -473,20 +473,32 @@ class AudiobookAlbum(Agent.Album):
             if date is not None:
                 year = date.year
 
+                # Make sure this isn't a pre-order listing
+                if helper.is_year_in_future(year):
+                    continue
+
             # Score the album name
             scorebase1 = media.album
             scorebase2 = title.encode('utf-8')
-
-            score = INITIAL_SCORE - Util.LevenshteinDistance(
+            album_score = INITIAL_SCORE - Util.LevenshteinDistance(
                 scorebase1, scorebase2
             )
+            log.debug("Score from album: " + str(album_score))
 
+            # Score the author name
             if media.artist:
                 scorebase3 = media.artist
                 scorebase4 = author
-                score = INITIAL_SCORE - Util.LevenshteinDistance(
+                author_score = INITIAL_SCORE - Util.LevenshteinDistance(
                     scorebase3, scorebase4
                 )
+                log.debug("Score from author: " + str(author_score))
+                # Find the difference in score between name and author
+                score = (
+                    album_score + author_score
+                ) - INITIAL_SCORE
+            else:
+                score = album_score
 
             log.info("Result #" + str(i + 1))
             # Log basic metadata

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -288,6 +288,12 @@ class AudiobookAlbum(Agent.Album):
             .replace("</p>", "\n")
         )
 
+        # Handle single genre result
+        if update_helper.genre_child:
+            genre_string = update_helper.genre_parent + ', ' + update_helper.genre_child
+        else:
+            genre_string = update_helper.genre_parent
+
         # Setup logging of all data in the array
         data_to_log = [
             {'date': update_helper.date},
@@ -295,7 +301,7 @@ class AudiobookAlbum(Agent.Album):
             {'author': update_helper.author},
             {'narrator': update_helper.narrator},
             {'series': update_helper.series},
-            {'genres': update_helper.genre_parent + ', ' + update_helper.genre_child},
+            {'genres': genre_string},
             {'studio': update_helper.studio},
             {'thumb': update_helper.thumb},
             {'rating': update_helper.rating},
@@ -699,7 +705,9 @@ class AudiobookAlbum(Agent.Album):
         if not Prefs['no_overwrite_genre']:
             helper.metadata.genres.clear()
             helper.metadata.genres.add(helper.genre_parent)
-            helper.metadata.genres.add(helper.genre_child)
+            # Not all books have 2 genres
+            if helper.genre_child:
+                helper.metadata.genres.add(helper.genre_child)
 
         self.parse_author_narrator(helper)
 

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -480,7 +480,7 @@ class AudiobookAlbum(Agent.Album):
                 year = date.year
 
                 # Make sure this isn't a pre-order listing
-                if helper.is_year_in_future(year):
+                if helper.check_if_preorder(date):
                     continue
 
             # Score the album name

--- a/Contents/Code/search_tools.py
+++ b/Contents/Code/search_tools.py
@@ -14,9 +14,9 @@ class SearchTool:
         self.media = media
         self.results = results
 
-    def is_year_in_future(self, year):
-        current_year = (date.today().year)
-        if year > current_year:
+    def check_if_preorder(self, book_date):
+        current_date = (date.today())
+        if book_date > current_date:
             return True
 
     def get_id_from_url(self, item):

--- a/Contents/Code/search_tools.py
+++ b/Contents/Code/search_tools.py
@@ -1,3 +1,4 @@
+from datetime import date
 import re
 # Import internal tools
 from logging import Logging
@@ -12,6 +13,11 @@ class SearchTool:
         self.manual = manual
         self.media = media
         self.results = results
+
+    def is_year_in_future(self, year):
+        current_year = (date.today().year)
+        if year > current_year:
+            return True
 
     def get_id_from_url(self, item):
         url = item['url']

--- a/Contents/Code/update_tools.py
+++ b/Contents/Code/update_tools.py
@@ -55,6 +55,12 @@ class UpdateTool:
                     )
                 except AttributeError:
                     continue
+                except IndexError:
+                    log.info(
+                        '"' + self.title + '", '
+                        "only has one genre"
+                        )
+                    continue
 
     # Writes metadata information to log.
     def writeInfo(self):


### PR DESCRIPTION
### Enhancements:
- Don't include pre-orders in search results

### Fixes:
- Fix https://github.com/seanap/Audiobooks.bundle/issues/15 :
Score was getting overwritten by artist score when present. So it was essentially just showing all the artists' books in the  order Audible returned them.
- Fix https://github.com/seanap/Audiobooks.bundle/issues/17