### PR TITLE
Use real log levels

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -34,7 +34,7 @@ def ValidatePrefs():
 
 
 def Start():
-    # HTTP.ClearCache()
+    HTTP.ClearCache()
     HTTP.CacheTime = CACHE_1WEEK
     HTTP.Headers['User-agent'] = (
         'Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.2; Trident/4.0;'
@@ -120,7 +120,7 @@ class AudiobookArtist(Agent.Artist):
         log.debug(
             '* Artist:           %s', media.artist
         )
-        log.debug(
+        log.error(
             '****************************************'
             'Not Ready For Artist Search Yet'
             '****************************************'
@@ -140,7 +140,7 @@ class AudiobookArtist(Agent.Artist):
                 try:
                     func(*args, **kargs)
                 except Exception as e:
-                    log.info(e)
+                    log.error(e)
                 queue.task_done()
             except Queue.Empty:
                 continue
@@ -184,7 +184,7 @@ class AudiobookAlbum(Agent.Album):
 
         # Write search result status to log
         if not result:
-            log.info(
+            log.warn(
                 'No results found for query "%s"',
                 normalizedName
             )
@@ -250,7 +250,7 @@ class AudiobookAlbum(Agent.Album):
         try:
             html = HTML.ElementFromURL(url, sleep=REQUEST_DELAY)
         except Exception as e:
-            log.info(e)
+            log.error(e)
 
         # Instantiate update helper
         update_helper = UpdateTool(force, lang, media, metadata, url)
@@ -627,7 +627,6 @@ class AudiobookAlbum(Agent.Album):
                 r'([^\\])(\\(?![bfnrt\'\"\\/]|u[A-Fa-f0-9]{4}))'
             )
             page_content = remove_inv_json_esc.sub(r'\1\\\2', page_content)
-            log.debug(page_content)
             json_data = self.json_decode(page_content)
 
             helper.re_parse_with_date_published(json_data)
@@ -887,7 +886,7 @@ class AudiobookAlbum(Agent.Album):
                 try:
                     func(*args, **kargs)
                 except Exception as e:
-                    log.info(e)
+                    log.error(e)
                 queue.task_done()
             except Queue.Empty:
                 continue

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -790,10 +790,10 @@ class AudiobookAlbum(Agent.Album):
         """
             Adds book series' to moods, since collections are not supported
         """
-
-        helper.metadata.moods.add(helper.series)
+        if helper.series:
+            helper.metadata.moods.add("Series: " + helper.series)
         if helper.series2:
-            helper.metadata.moods.add(helper.series2)
+            helper.metadata.moods.add("Series: " + helper.series2)
 
     def parse_series(self, helper):
         # Clean series

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -10,7 +10,7 @@ from search_tools import SearchTool
 from update_tools import UpdateTool
 from urls import SiteUrl
 
-VERSION_NO = '2021.08.29.2'
+VERSION_NO = '2021.08.30.1'
 
 # Delay used when requesting HTML,
 # may be good to have to prevent being banned from the site

--- a/Contents/Code/logging.py
+++ b/Contents/Code/logging.py
@@ -1,16 +1,50 @@
 class Logging:
-    # Only prints message with debug mode
     def debug(self, message, *args):
-        if Prefs['debug']:
-            return Log(message, *args)
+        """
+            Prints passed message with DEBUG TYPE,
+            when DEBUG pref enabled.
+        """
+        if Prefs['logging_level'] == "DEBUG":
+            return Log.Debug(message, *args)
 
     # Prints any message you give
     def info(self, message, *args):
-        return Log(message, *args)
+        """
+            Prints passed message with INFO TYPE,
+            when INFO or DEBUG pref enabled.
+        """
+        if Prefs['logging_level'] == "DEBUG" or (
+            Prefs['logging_level'] == "INFO"
+        ):
+            return Log(message, *args)
+
+    def warning(self, message, *args):
+        """
+            Prints passed message with INFO TYPE,
+            when DEBUG, INFO or WARN pref enabled.
+        """
+        if Prefs['logging_level'] == "DEBUG" or (
+            Prefs['logging_level'] == "INFO") or (
+                Prefs['logging_level'] == "WARN"
+                ):
+            # No builtin warn, so use info level for it
+            return Log(message, *args)
+
+    def error(self, message, *args):
+        """
+            Prints passed message with ERROR TYPE,
+            when DEBUG, INFO, WARN or ERROR pref enabled.
+        """
+        if Prefs['logging_level'] == "DEBUG" or (
+            Prefs['logging_level'] == "INFO") or (
+                Prefs['logging_level'] == "WARN") or (
+                    Prefs['logging_level'] == "ERROR"
+                    ):
+            return Log.Error(message, *args)
 
     # For the below logging:
     # Default level is info
-    # Set debug by calling ('sometext', 'debug')
+    # Set debug by calling (msg='sometext', log_level='debug')
 
     # Prints a bunch of divider chars like ---
     def separator(self, msg=None, log_level="info"):

--- a/Contents/Code/search_tools.py
+++ b/Contents/Code/search_tools.py
@@ -17,7 +17,7 @@ class SearchTool:
     def check_if_preorder(self, book_date):
         current_date = (date.today())
         if book_date > current_date:
-            log.debug("Excluding pre-order book")
+            log.info("Excluding pre-order book")
             return True
 
     def get_id_from_url(self, item):
@@ -29,7 +29,7 @@ class SearchTool:
         if asin:
             return asin
 
-        log.info('No Match: %s', url)
+        log.warn('No Match: %s', url)
         return None
 
     def pre_search_logging(self):

--- a/Contents/Code/update_tools.py
+++ b/Contents/Code/update_tools.py
@@ -80,7 +80,7 @@ class UpdateTool:
 
         # Log basic metadata stored in arrays
         multi_arr = [
-            {'Genres & Series': self.metadata.genres},
+            {'Genres': self.metadata.genres},
             {'Moods(Authors)': self.metadata.moods},
             {'Styles(Narrators)': self.metadata.styles},
         ]

--- a/Contents/Code/update_tools.py
+++ b/Contents/Code/update_tools.py
@@ -56,7 +56,7 @@ class UpdateTool:
                 except AttributeError:
                     continue
                 except IndexError:
-                    log.info(
+                    log.warn(
                         '"' + self.title + '", '
                         "only has one genre"
                         )

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -37,8 +37,14 @@
 	"type": "bool",
 	"default": "false"
 },{
-	"id": "debug",
-	"label": "Ouput debugging info in logs",
-	"type": "bool",
-	"default": "false"
+	"id": "logging_level",
+	"label": "Level of plugin logging: ",
+	"type": "enum",
+	"values": [
+		"DEBUG",
+		"INFO",
+		"WARN",
+		"ERROR"
+	],
+	"default": "WARN"
 }]


### PR DESCRIPTION
### New preference
- "Level of plugin  logging":
  - Controls how many messages are printed out to you by the plugin.

### Enhancements
- Set logs to appropriate levels. Closes https://github.com/seanap/Audiobooks.bundle/issues/14

### Fixes:
- Don't add empty series as mood.