### PR TITLE
Truncate long titles, use initials for prenames, add narrator to search result

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -10,7 +10,7 @@ from search_tools import SearchTool
 from update_tools import UpdateTool
 from urls import SiteUrl
 
-VERSION_NO = '2021.09.21.1'
+VERSION_NO = '2021.09.23.1'
 
 # Starting value for score before deductions are taken.
 INITIAL_SCORE = 100
@@ -208,8 +208,14 @@ class AudiobookAlbum(Agent.Album):
         log.separator(log_level="debug")
         log.debug('Final result:')
         for i, r in enumerate(info):
+            # Truncate title if too long
+            # Displayable chars is ~60 (see issue #32)
+            # Inlcude tolerance to only truncate if >4 chars need to be cut
+            title_trunc = (r['title'][:32] + '..') if len(
+                r['title']) > 38 else r['title']
+            
             description = '\"%s\" %s %s' % (
-                r['title'], localized_sep, r['artist']
+                title_trunc, localized_sep, r['artist']
             )
             log.debug(
                 '    [%s]    %s. %s (%s) %s {%s} [%s]',

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -365,7 +365,7 @@ class AudiobookAlbum(Agent.Album):
         # and merged with dots.
         # Example: 'Arthur Conan Doyle' -> 'A.C.Doyle'
         name_parts = input_name.split()
-        new_Name = ""
+        new_name = ""
         
         # Check if prename and surname exist, otherwise exit
         if len(name_parts) < 2:
@@ -375,11 +375,11 @@ class AudiobookAlbum(Agent.Album):
         for i in range(len(name_parts)-1):
             s = name_parts[i]
             # If prename already is an initial take it as is
-            new_Name += (s[0] + '.') if len(s)>2 and s[1]!='.' else s
+            new_name += (s[0] + '.') if len(s)>2 and s[1]!='.' else s
         # Add surname
-        new_Name += name_parts[-1]
+        new_name += name_parts[-1]
         
-        return new_Name
+        return new_name
     
     def create_search_url(self, ctx, helper):
         # Make the URL

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -199,7 +199,10 @@ class AudiobookAlbum(Agent.Album):
             'it': 'di'
         }
         localized_sep = by_lang_dict.get(lang, "by")
-        log.debug("Localized separator between title and artist: " + localized_sep)
+        log.debug(
+            'Using localized separator "%s" between title and artist',
+            localized_sep
+        )
 
         # Output the final results.
         log.separator(log_level="debug")
@@ -388,7 +391,6 @@ class AudiobookAlbum(Agent.Album):
                 cleaned_datetext = re.search(r'\d{2}[.]\d{2}[.]\d{4}', datetext)
 
             date = self.getDateFromString(cleaned_datetext.group(0))
-            log.debug("Parsed Date: " + str(date))
             language = self.getStringContentFromXPath(
                 r, (
                     u'div/div/div/div/div/div/span/ul/li'
@@ -557,7 +559,11 @@ class AudiobookAlbum(Agent.Album):
         }
 
         if language != lang_dict[helper.lang]:
-            log.debug("Audible language: " + language + "; Library language: " + helper.lang)
+            log.debug(
+                'Audible language: %s; Library language: %s',
+                language,
+                helper.lang
+            )
             log.debug("Book is not library language, deduct 2 points")
             return 2
         return 0

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -191,17 +191,19 @@ class AudiobookAlbum(Agent.Album):
 
         info = self.run_search(search_helper, result)
         
-        # Set localized "by"
-        by_lang_dict = {
-            Locale.Language.English: 'by',
-            'de': 'von',
-            'fr': 'de',
-            'it': 'di'
+        # Nested dict for localized separators
+        # 'T_A' is the separator between title and author
+        # 'A_N' is the separator between author and narrator
+        sep_dict = {
+            Locale.Language.English: {'T_A': 'by', 'A_N': 'with'},
+            'de': {'T_A': 'von', 'A_N': 'mit'},
+            'fr': {'T_A': 'de', 'A_N': 'avec'},
+            'it': {'T_A': 'di', 'A_N': 'con'}
         }
-        localized_sep = by_lang_dict.get(lang, "by")
+        local_seps = sep_dict[lang]
         log.debug(
-            'Using localized separator "%s" between title and artist',
-            localized_sep
+            'Using localized separators "%s" and "%s"',
+            local_seps['T_A'], local_seps['A_N'] 
         )
 
         # Output the final results.
@@ -219,8 +221,12 @@ class AudiobookAlbum(Agent.Album):
             # Shorten narrator
             nr_inits = self.name_to_initials(r['narrator'])
             
-            description = '\"%s\" %s %s with %s' % (
-                title_trunc, localized_sep, artist_inits, nr_inits
+            description = '\"%s\" %s %s %s %s' % (
+                title_trunc,
+                local_seps['T_A'],
+                artist_inits, 
+                local_seps['A_N'], 
+                nr_inits
             )
             log.debug(
                 '  [%s]  %s. %s (%s) %s; %s {%s} [%s]',

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -216,14 +216,16 @@ class AudiobookAlbum(Agent.Album):
             
             # Shorten artist
             artist_inits = self.name_to_initials(r['artist'])
+            # Shorten narrator
+            nr_inits = self.name_to_initials(r['narrator'])
             
-            description = '\"%s\" %s %s' % (
-                title_trunc, localized_sep, artist_inits
+            description = '\"%s\" %s %s with %s' % (
+                title_trunc, localized_sep, artist_inits, nr_inits
             )
             log.debug(
-                '  [%s]  %s. %s (%s) %s {%s} [%s]',
+                '  [%s]  %s. %s (%s) %s; %s {%s} [%s]',
                 r['score'], (i + 1), r['title'], r['year'],
-                r['artist'], r['id'], r['thumb']
+                r['artist'], r['narrator'], r['id'], r['thumb']
             )
             results.Append(
                 MetadataSearchResult(
@@ -541,7 +543,8 @@ class AudiobookAlbum(Agent.Album):
                     'date': date,
                     'score': score,
                     'thumb': thumb,
-                    'artist': author
+                    'artist': author,
+                    'narrator': narrator
                 }
             )
         else:

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -194,16 +194,16 @@ class AudiobookAlbum(Agent.Album):
         # Nested dict for localized separators
         # 'T_A' is the separator between title and author
         # 'A_N' is the separator between author and narrator
-        sep_dict = {
-            Locale.Language.English: {'T_A': 'by', 'A_N': 'with'},
+        separator_dict = {
+            Locale.Language.English: {'T_A': 'by', 'A_N': 'w/'},
             'de': {'T_A': 'von', 'A_N': 'mit'},
-            'fr': {'T_A': 'de', 'A_N': 'avec'},
+            'fr': {'T_A': 'de', 'A_N': 'ac'},
             'it': {'T_A': 'di', 'A_N': 'con'}
         }
-        local_seps = sep_dict[lang]
+        local_separators = separator_dict[lang]
         log.debug(
             'Using localized separators "%s" and "%s"',
-            local_seps['T_A'], local_seps['A_N'] 
+            local_separators['T_A'], local_separators['A_N'] 
         )
 
         # Output the final results.
@@ -213,20 +213,20 @@ class AudiobookAlbum(Agent.Album):
             # Truncate long titles
             # Displayable chars is ~60 (see issue #32)
             # Inlcude tolerance to only truncate if >4 chars need to be cut
-            title_trunc = (r['title'][:32] + '..') if len(
-                r['title']) > 38 else r['title']
+            title_trunc = (r['title'][:30] + '..') if len(
+                r['title']) > 36 else r['title']
             
             # Shorten artist
-            artist_inits = self.name_to_initials(r['artist'])
+            artist_initials = self.name_to_initials(r['artist'])
             # Shorten narrator
-            nr_inits = self.name_to_initials(r['narrator'])
+            narrator_initials = self.name_to_initials(r['narrator'])
             
             description = '\"%s\" %s %s %s %s' % (
                 title_trunc,
-                local_seps['T_A'],
-                artist_inits, 
-                local_seps['A_N'], 
-                nr_inits
+                local_separators['T_A'],
+                artist_initials, 
+                local_separators['A_N'], 
+                narrator_initials
             )
             log.debug(
                 '  [%s]  %s. %s (%s) %s; %s {%s} [%s]',
@@ -364,22 +364,22 @@ class AudiobookAlbum(Agent.Album):
         # Only the surname stays as whole, the rest gets truncated
         # and merged with dots.
         # Example: 'Arthur Conan Doyle' -> 'A.C.Doyle'
-        nameparts = input_name.split()
-        newName = ""
+        name_parts = input_name.split()
+        new_Name = ""
         
         # Check if prename and surname exist, otherwise exit
-        if len(nameparts) < 2:
+        if len(name_parts) < 2:
             return input_name
         
         # traverse through prenames
-        for i in range(len(nameparts)-1):
-            s = nameparts[i]
+        for i in range(len(name_parts)-1):
+            s = name_parts[i]
             # If prename already is an initial take it as is
-            newName += (s[0] + '.') if len(s)>2 and s[1]!='.' else s
+            new_Name += (s[0] + '.') if len(s)>2 and s[1]!='.' else s
         # Add surname
-        newName += nameparts[-1]
+        new_Name += name_parts[-1]
         
-        return newName
+        return new_Name
     
     def create_search_url(self, ctx, helper):
         # Make the URL

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -688,12 +688,12 @@ class AudiobookAlbum(Agent.Album):
             )
             page_content = remove_inv_json_esc.sub(r'\1\\\2', page_content)
             json_data = self.json_decode(page_content)
-
+            
             helper.re_parse_with_date_published(json_data)
-
+    
     def use_copyright_date(self, helper, html):
         cstring = None
-
+        
         for r in html.xpath(u'//span[contains(text(), "\xA9")]'):
             cstring = self.getStringContentFromXPath(
                 r, u'normalize-space(//span[contains(text(), "\xA9")])'
@@ -702,23 +702,13 @@ class AudiobookAlbum(Agent.Album):
             if cstring.startswith(u"\xA9 "):
                 cstring = ""
                 helper.date = helper.date[:4]
-
+        
         if cstring:
-            if "Public Domain" in cstring:
-                helper.date = re.match(".*\(P\)(\d{4})", cstring).group(1)
-            else:
-                if cstring.startswith(u'\xA9'):
-                    cstring = cstring[1:]
-                if "(P)" in cstring:
-                    cstring = re.match("(.*)\(P\).*", cstring).group(1)
-                if ";" in cstring:
-                    helper.date = str(
-                        min(
-                            [int(i) for i in cstring.split() if i.isdigit()]
-                        )
-                    )
-                else:
-                    helper.date = re.match(".?(\d{4}).*", cstring).group(1)
+            if cstring.startswith(u'\xA9'):
+                # strip copyright symbol
+                cstring = cstring[1:]
+            # match first 4 digits found
+            helper.date = re.search(r'\d{4}', cstring).group()
 
     def handle_series(self, helper, html):
         for r in html.xpath('//li[contains(@class, "seriesLabel")]'):


### PR DESCRIPTION
To prevent long titles from consuming all visible space I suggest to truncate these titles.
Considering display behaviours from my experience and two others (see #32) plex seems to truncate at ~60 chars.
Therefore I chose a limit of 38 chars above which titles will be truncated to 32 chars + '..'.
That should leave enough space for author and possibly narrator.